### PR TITLE
Make sure git remote is up-to-date

### DIFF
--- a/features/changelog.feature
+++ b/features/changelog.feature
@@ -1,8 +1,4 @@
 Feature: Changelog
-  As a stove user
-  In order to have a human-readable changeset
-  I want to automatically generate a Changelog
-
   Background:
     * the CLI options are all off
     * I have a cookbook named "bacon"

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -1,8 +1,4 @@
 Feature: Cli
-  As a stove user
-  In order to use Stove
-  I want to have a Cli that is useful
-
   Background:
     * I have a cookbook named "bacon"
 

--- a/features/git.feature
+++ b/features/git.feature
@@ -1,8 +1,4 @@
 Feature: Git
-  As a stove user
-  In order to have a useful git tree
-  I want to automatically tag and push to git
-
   Background:
     * the CLI options are all off
 
@@ -30,3 +26,9 @@ Feature: Git
     * I have a cookbook named "bacon"
     * I run `bake 1.0.0 --git`
     * the exit status will be "GitError::NotARepo"
+
+  Scenario: Remote repository out of sync
+    * I have a cookbook named "bacon" with git support
+    * the remote repository has additional commits
+    * I run `bake 1.0.0 --git`
+    * the exit status will be "GitError::OutOfSync"

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -13,11 +13,14 @@ When /^the CLI options are all off$/ do
     private
       def options
         @options ||= {
-          :git       => false,
-          :jira      => false,
-          :upload    => false,
-          :changelog => false,
-          :log_level => :debug,
+          path:      Dir.pwd,
+          git:       false,
+          remote:    'origin',
+          branch:    'master',
+          jira:      false,
+          upload:    false,
+          changelog: false,
+          log_level: :fatal,
         }
       end
   end

--- a/features/step_definitions/community_site_steps.rb
+++ b/features/step_definitions/community_site_steps.rb
@@ -4,8 +4,8 @@ Given /^the Community Site has the cookbooks?:$/ do |table|
     category ||= 'Other'
 
     CommunityZero::Cookbook.create({
-      name: name,
-      version: version,
+      name:     name,
+      version:  version,
       category: category,
     })
   end

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -1,3 +1,11 @@
+Given /^the remote repository has additional commits/ do
+  Dir.chdir(fake_git_remote) do
+    shellout 'touch myfile.txt'
+    git 'add myfile.txt'
+    git 'commit -m "Add a new file"'
+  end
+end
+
 Then /^the git remote will( not)? have the commit "(.+)"$/ do |negate, message|
   commits = git_commits(fake_git_remote)
 

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -1,8 +1,4 @@
 Feature: Upload
-  As a stove user
-  In order to upload cookbooks
-  I want to tar and push to a Community Site
-
   Background:
     * I have a cookbook named "bacon"
     * the CLI options are all off

--- a/lib/stove/cli.rb
+++ b/lib/stove/cli.rb
@@ -92,14 +92,14 @@ module Stove
       # @return [Hash]
       def options
         @options ||= {
-          :path      => Dir.pwd,
-          :git       => true,
-          :remote    => 'origin',
-          :branch    => 'master',
-          :jira      => false,
-          :upload    => true,
-          :changelog => true,
-          :log_level => :warn,
+          path:      Dir.pwd,
+          git:       true,
+          remote:    'origin',
+          branch:    'master',
+          jira:      false,
+          upload:    true,
+          changelog: true,
+          log_level: :warn,
         }
       end
 

--- a/lib/stove/cookbook.rb
+++ b/lib/stove/cookbook.rb
@@ -88,6 +88,7 @@ module Stove
       if options[:git]
         validate_git_repo!
         validate_git_clean!
+        validate_remote_updated!
       end
 
       version_bump
@@ -274,6 +275,16 @@ module Stove
       def validate_git_clean!
         Dir.chdir(path) do
           raise Stove::GitError::DirtyRepo unless git_repo_clean?
+        end
+      end
+
+      # Validate that the remote git repository is up to date.
+      #
+      # @raise [Stove::GitError::OutOfSync]
+      #   if the current git repo is not up to date with the remote
+      def validate_remote_updated!
+        Dir.chdir(path) do
+          raise Stove::GitError::OutOfSync unless git_remote_uptodate?(options)
         end
       end
   end

--- a/lib/stove/error.rb
+++ b/lib/stove/error.rb
@@ -70,6 +70,14 @@ module Stove
         'You have untracked files!'
       end
     end
+
+    class OutOfSync < GitError
+      set_exit_code 133
+
+      def message
+        'Your remote repository is out of sync!'
+      end
+    end
   end
 
   class UploadError < Error

--- a/lib/stove/git.rb
+++ b/lib/stove/git.rb
@@ -44,6 +44,14 @@ module Stove
       false
     end
 
+    def git_remote_uptodate?(options = {})
+      git('fetch')
+      local  = git("rev-parse #{options[:branch]}").strip
+      remote = git("rev-parse #{options[:remote]}/#{options[:branch]}").strip
+
+      local == remote
+    end
+
     def shellout(command)
       out, err = Tempfile.new('shellout.stdout'), Tempfile.new('shellout.stderr')
 

--- a/spec/support/git.rb
+++ b/spec/support/git.rb
@@ -11,6 +11,7 @@ module Stove
           git 'add --all'
           git 'commit --message "Initial commit"'
           git 'remote add origin file://' + fake_git_remote
+          git 'push origin master'
         end
       end
 


### PR DESCRIPTION
Stove should automatically check the git remote (if the `--git` option is passed) and do something about upstream changes.
