### PR TITLE
Duplicate frozen value rubygems < 2 will modify

### DIFF
--- a/lib/stove/actions/bump.rb
+++ b/lib/stove/actions/bump.rb
@@ -8,7 +8,7 @@ module Stove
     end
 
     validate(:incremented) do
-      version = Gem::Version.new(options[:version])
+      version = Gem::Version.new(options[:version].dup)
       Gem::Requirement.new("> #{cookbook.version}").satisfied_by?(version)
     end
 


### PR DESCRIPTION
Was getting some errors about modifying frozen strings (seen [here](https://gist.github.com/RoboticCheese/8443728)) and tracked them down to [this](https://github.com/rubygems/rubygems/commit/48f1d869510dcd325d6566df7d0147a086905380#diff-94d386526b8b558035d4e4c7602d647c).

Pre-2.0 Rubygems tries to modify the argument passed to `Gem::Version.new`. I'll upgrade my system, but the fix was easy enough. Doesn't seem to be a good way to test this in Travis, though, without slowing the build down installing different versions.
