### PR TITLE
WIP: Update version of solve gem to match Berkshelf.

### DIFF
--- a/stove.gemspec
+++ b/stove.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'minitar',               '~> 0.5'
   spec.add_dependency 'mixlib-authentication', '~> 1.3'
   spec.add_dependency 'octokit',               '~> 3.0'
-  spec.add_dependency 'solve',                 '~> 0.8'
+  spec.add_dependency 'solve',                 '~> 1.2'
 
   spec.add_development_dependency 'aruba',          '~> 0.5'
   spec.add_development_dependency 'bundler',        '~> 1.3'


### PR DESCRIPTION
The latest version of Berkshelf uses a newer version of the solve
gem. This matches that.
