### PR TITLE
Add development comment next to version in the metadata

### DIFF
--- a/features/actions/bump.feature
+++ b/features/actions/bump.feature
@@ -15,6 +15,7 @@ Feature: Bump
   Scenario: In isolation
     * I successfully run `bake 2.0.0 --bump`
     * the file "metadata.rb" should contain "2.0.0"
+    * the file "metadata.rb" should not contain "# development version"
 
   Scenario: With the git plugin
     * I have a cookbook named "bacon" with git support

--- a/features/actions/dev.feature
+++ b/features/actions/dev.feature
@@ -11,6 +11,7 @@ Feature: Dev
   Scenario: With bump
     * I successfully run `bake 2.0.0 --bump --dev`
     * the file "metadata.rb" should contain "2.0.1"
+    * the file "metadata.rb" should match /^version .* # development version$/
 
   Scenario: With the git plugin
     * I have a cookbook named "bacon" with git support

--- a/lib/stove/actions/dev.rb
+++ b/lib/stove/actions/dev.rb
@@ -8,7 +8,7 @@ module Stove
       log.debug("Version is currently #{cookbook.version}")
       log.debug("Bumped version is #{dev_version}")
 
-      cookbook.bump(dev_version)
+      cookbook.bump(dev_version, 'development version')
 
       log.debug("Version is now #{cookbook.version}")
     end

--- a/lib/stove/cookbook.rb
+++ b/lib/stove/cookbook.rb
@@ -146,17 +146,22 @@ module Stove
     #
     # @param [String] new_version
     #   the version to bump to
+    # @param [String] commant
+    #   a comment to add to the version
     #
     # @return [String]
     #   the new version string
     #
-    def bump(new_version)
+    def bump(new_version, comment = nil)
       return true if new_version.to_s == version.to_s
 
       metadata_path = path.join('metadata.rb')
       contents      = File.read(metadata_path)
 
-      contents.sub!(/^version(\s+)('|")#{version}('|")/, "version\\1\\2#{new_version}\\3")
+      contents.sub!(
+        /^version(\s+)('|")#{version}('|").*$/,
+        "version\\1\\2#{new_version}\\3#{comment.gsub(/^/, ' # ') if comment.kind_of?(String)}"
+      )
 
       File.open(metadata_path, 'w') { |f| f.write(contents) }
       reload_metadata!


### PR DESCRIPTION
This PR adds a "development" comment in the _dev_ versions. Something like the following:

``` ruby
version "2.0.1" # development version
```
