### PR TITLE
The tarball's structure mirrors the existing directory structure

### DIFF
--- a/lib/stove/packager.rb
+++ b/lib/stove/packager.rb
@@ -54,26 +54,15 @@ module Stove
     # @return [Hash<String, String>]
     #   the map of file paths
     def packaging_slip
-      root = File.dirname(cookbook.path)
-      path = File.expand_path("#{cookbook.path}/{#{ACCEPTABLE_FILES_LIST}}")
+      root = File.expand_path(cookbook.path)
+      path = File.join(root, "{#{ACCEPTABLE_FILES_LIST}}")
 
       Dir[path].reject do |filepath|
         TMP_FILES.any? { |regex| filepath.match(regex) }
       end.map do |cookbook_file|
         [
           cookbook_file,
-          cookbook_file.sub(/^#{Regexp.escape(root)}\/?/, '')
-        ]
-      end.map do |cookbook_file, relative_file|
-        [
-          cookbook_file,
-          relative_file,
-          Regexp.escape(File.dirname(relative_file))
-        ]
-      end.map do |cookbook_file, relative_file, relative_base_dir|
-        [
-          cookbook_file,
-          relative_file.sub(/^#{relative_base_dir}/, cookbook.name)
+          cookbook_file.sub(/^#{Regexp.escape(root)}/, cookbook.name)
         ]
       end.reduce({}) do |map, (cookbook_file, tarball_file)|
         map[cookbook_file] = tarball_file

--- a/spec/integration/cookbook_spec.rb
+++ b/spec/integration/cookbook_spec.rb
@@ -3,9 +3,16 @@ require 'spec_helper'
 describe Stove::Cookbook do
   describe '#tarball' do
     it 'contains a directory with the same name as the cookbook' do
-      FileUtils.mkdir_p('tmp/basic-cookbook')
+      FileUtils.mkdir_p('tmp/basic-cookbook/recipes')
+      FileUtils.mkdir_p('tmp/basic-cookbook/templates/default')
       File.open('tmp/basic-cookbook/metadata.rb', 'w+') do |f|
         f.puts "name 'basic'"
+      end
+      File.open('tmp/basic-cookbook/recipes/default.rb', 'w+') do |f|
+        f.puts '# default.rb'
+      end
+      File.open('tmp/basic-cookbook/templates/default/basic.erb', 'w+') do |f|
+        f.puts '# basic.erb'
       end
 
       tarball = Stove::Cookbook.new('tmp/basic-cookbook').tarball
@@ -17,7 +24,12 @@ describe Stove::Cookbook do
         end
       end
 
-      expect(tarball_directories).to include('basic')
+      expect(tarball_directories.uniq).to eql([
+        'basic',
+        'basic/recipes',
+        'basic/templates',
+        'basic/templates/default'
+      ])
     end
   end
 end


### PR DESCRIPTION
I expanded the Cookbook's integration spec to reproduce #51, and updated the Packager implementation to make the spec pass.
