### PR TITLE
Update README for private supermarket

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ The default publishing endpoint is the [Chef Supermarket](https://supermarket.ge
 $ stove --endpoint https://internal-cookbook-store.example.com
 ```
 
+or for a private supermarket using the [supermarket](https://supermarket.getchef.com/cookbooks/supermarket) cookbook:
+
+```bash
+$ stove --endpoint https://internal-cookbook-store.example.com/api/v1
+```
 
 Usage
 -----


### PR DESCRIPTION
Minor addition to the README to note that a private supermarket (at least one using the supermarket cookbook) endpoint ends in /api/v1.

Trying to follow the former README example with a private supermarket just gives a HTTP 500 error, which I only figured out by comparing the nginx logs and comparing the calls from `knife supermarket list` vs `stove --endpoint ...`

I'm not sure if the public supermarket is doing additional rewriting so that /cookbooks is rewritten to /api/v1/cookbooks, but using a recent (v2.12.0) version of that cookbook to stand up a private supermarket definitely requires the extra parts in the endpoint to work with stove.
