### PR TITLE
Include `metadata.rb`

### DIFF
--- a/lib/stove/packager.rb
+++ b/lib/stove/packager.rb
@@ -10,7 +10,7 @@ module Stove
     ACCEPTABLE_FILES = [
       'README.*',
       'CHANGELOG.*',
-      'metadata.json',
+      'metadata.{json,rb}',
       'attributes/*.rb',
       'definitions/*.rb',
       'files/**/*',

--- a/spec/integration/cookbook_spec.rb
+++ b/spec/integration/cookbook_spec.rb
@@ -27,6 +27,7 @@ module Stove
           basic/files/default/patch.txt
           basic/libraries/magic.rb
           basic/metadata.json
+          basic/metadata.rb
           basic/providers/thing.rb
           basic/recipes/default.rb
           basic/recipes/system.rb


### PR DESCRIPTION
Without this file stove does not conform to the same specs as
`knife cookbook site share COOKBOOK` and this causes issues with
later steps in the workflow.

For example, `knife cookbook site install COOKBOOK` will fail for
some cookbooks as it reads the `metadata.rb` to resolve dependencies.
