### PR TITLE
Only populate extended metadata fields if the --extended-metadata flag was used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@ Stove CHANGELOG
 ===============
 This is the Changelog for the Stove gem.
 
+Unreleased
+----------
+- only publish extended metadata fields if the flag is provided and the
+  value is set in metadata.rb.  This prevents Supermarket from rejecting
+  uploads where e.g. source_url is set but issues_url is not
+
 v3.2.7 (2015-04-16)
 -------------------
 - Use chef.io instead of getchef.com

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@ Stove CHANGELOG
 ===============
 This is the Changelog for the Stove gem.
 
-Unreleased
-----------
-- only publish extended metadata fields if the flag is provided and the
-  value is set in metadata.rb.  This prevents Supermarket from rejecting
-  uploads where e.g. source_url is set but issues_url is not
-
 v3.2.7 (2015-04-16)
 -------------------
 - Use chef.io instead of getchef.com

--- a/lib/stove/cookbook/metadata.rb
+++ b/lib/stove/cookbook/metadata.rb
@@ -183,8 +183,10 @@ module Stove
         }
 
         if extended_metadata
-          hash['source_url'] = self.source_url
-          hash['issues_url'] = self.issues_url
+          %w(source_url issues_url).each do |attr|
+            attrval = self.send(attr.to_sym)
+            hash[attr] = attrval unless attrval.empty?
+          end
         end
 
         return hash

--- a/lib/stove/cookbook/metadata.rb
+++ b/lib/stove/cookbook/metadata.rb
@@ -183,10 +183,8 @@ module Stove
         }
 
         if extended_metadata
-          %w(source_url issues_url).each do |attr|
-            attrval = self.send(attr.to_sym)
-            hash[attr] = attrval unless attrval.empty?
-          end
+          hash['source_url'] = self.source_url if !self.source_url.empty?
+          hash['issues_url'] = self.issues_url if !self.issues_url.empty?
         end
 
         return hash

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -13,9 +13,39 @@ class Stove::Cookbook
 
       context 'when the extra metadata is included' do
         it 'includes the new metadata fields' do
+          subject.source_url('http://foo.example.com')
+          subject.issues_url('http://bar.example.com')
           hash = subject.to_hash(true)
           expect(hash).to include('issues_url')
+          expect(hash['source_url']).to eq 'http://foo.example.com'
           expect(hash).to include('source_url')
+          expect(hash['issues_url']).to eq 'http://bar.example.com'
+        end
+      end
+
+      context 'when the extra metadata is not defined' do
+        it 'does not include the new metadata fields' do
+          hash = subject.to_hash(true)
+          expect(hash).not_to include('source_url')
+          expect(hash).not_to include('issues_url')
+        end
+      end
+
+      context 'when only some of the extra metadata is defined' do
+        it 'only includes the source_url if issues_url is empty' do
+          subject.source_url('http://foo.example.com')
+          hash = subject.to_hash(true)
+          expect(hash).to include('source_url')
+          expect(hash['source_url']).to eq 'http://foo.example.com'
+          expect(hash).not_to include('issues_url')
+        end
+
+        it 'only includes the issues_url if source_url is empty' do
+          subject.issues_url('http://bar.example.com')
+          hash = subject.to_hash(true)
+          expect(hash).to include('issues_url')
+          expect(hash['issues_url']).to eq 'http://bar.example.com'
+          expect(hash).not_to include('source_url')
         end
       end
     end


### PR DESCRIPTION
Only populate extended metadata fields if the --extended-metadata flag was used
*and* the field is not empty.  This prevents supermarket from rejecting cookbook
uploads where e.g. source_url is set but issues_url is not.

Closes #81 