### PR TITLE
Add contributing and maintainers docs to the tarball

### DIFF
--- a/lib/stove/packager.rb
+++ b/lib/stove/packager.rb
@@ -10,6 +10,8 @@ module Stove
     ACCEPTABLE_FILES = [
       'README.*',
       'CHANGELOG.*',
+      'CONTRIBUTING.md',
+      'MAINTAINERS.md',
       'metadata.json',
       'attributes/*.rb',
       'definitions/*.rb',


### PR DESCRIPTION
Contributing and maintainers docs should be present for anyone downloading an artifact.