### PR TITLE
push .foodcritic to supermarket

### DIFF
--- a/lib/stove/packager.rb
+++ b/lib/stove/packager.rb
@@ -8,6 +8,7 @@ module Stove
     include Logify
 
     ACCEPTABLE_FILES = [
+      '.foodcritic',
       'README.*',
       'CHANGELOG.*',
       'CONTRIBUTING.md',

--- a/spec/integration/cookbook_spec.rb
+++ b/spec/integration/cookbook_spec.rb
@@ -16,6 +16,7 @@ module Stove
         end
 
         expect(structure).to eq(%w(
+          basic/.foodcritic
           basic/CHANGELOG.md
           basic/README.md
           basic/attributes/default.rb

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -20,6 +20,11 @@ module Stove
         FileUtils.mkdir_p(root.join('templates', 'default'))
 
         # Files
+        File.open(root.join('.foodcritic'), 'wb') do |f|
+          f.write <<-EOH.gsub(/^ {11}/, '')
+            ~FC031 ~FC045
+          EOH
+        end
         File.open(root.join('metadata.rb'), 'wb') do |f|
           f.write <<-EOH.gsub(/^ {11}/, '')
             name '#{cookbook_name}'


### PR DESCRIPTION
lets users disable tests that are otherwise impossible to disable
in the code (like warning about the absence of a file).