### PR TITLE
Lock down aruba to prevent cucumber 2.0 from being used

### DIFF
--- a/stove.gemspec
+++ b/stove.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'chef-api', '~> 0.5'
   spec.add_dependency 'logify',   '~> 0.2'
 
-  spec.add_development_dependency 'aruba',          '~> 0.6'
+  spec.add_development_dependency 'aruba',          '~> 0.6.0'
   spec.add_development_dependency 'bundler',        '~> 1.6'
   spec.add_development_dependency 'community-zero', '~> 2.0'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Cucumber 2 breaks the travis runs at the moment