### PR TITLE
Updated last_comment to last_description per deprecation warning

### DIFF
--- a/lib/stove/rake_task.rb
+++ b/lib/stove/rake_task.rb
@@ -9,7 +9,7 @@ module Stove
     def initialize(name = nil)
       yield self if block_given?
 
-      desc 'Publish this cookbook' unless ::Rake.application.last_comment
+      desc 'Publish this cookbook' unless ::Rake.application.last_description
       task(name || :publish) do |t, args|
         Cli.new(stove_opts || []).execute!
       end


### PR DESCRIPTION
Running `rake -T` when the `Stove::RakeTask` is included in a Rakefile causes the following error:

```
[DEPRECATION] `last_comment` is deprecated.  Please use `last_description` instead.
rake publish     # Publish this cookbook
```

This PR updates the `lib/stove/rake_task.rb` file to use `last_description` as discussed in the deprecation warning. Tested that this works by building and installing the gem locally and ran `rake -T` again from my project.