### PR TITLE
Do not delete metadata.json if metadata.rb is not present

### DIFF
--- a/lib/stove/packager.rb
+++ b/lib/stove/packager.rb
@@ -97,7 +97,7 @@ module Stove
       tempfile.rewind
       tempfile
     ensure
-      if defined?(metadata_json)
+      if defined?(metadata_json) && File.exist?(File.join(cookbook.path, 'metadata.rb'))
         File.delete(metadata_json)
       end
     end


### PR DESCRIPTION
Sorry @sethvargo and @tas50  - Forgot to catch the delete of metadata.json in lib/stove/packager.rb.  Added a check to see if metadata.rb is present before deleting metadata.json.