### PR TITLE
Allow partially empty extended metadata

### DIFF
--- a/lib/stove/cookbook/metadata.rb
+++ b/lib/stove/cookbook/metadata.rb
@@ -190,8 +190,8 @@ module Stove
         }
 
         if extended_metadata
-          hash['source_url']   = self.source_url
-          hash['issues_url']   = self.issues_url
+          hash['source_url']   = self.source_url unless self.source_url.empty?
+          hash['issues_url']   = self.issues_url unless self.issues_url.empty?
           hash['chef_version'] = self.chef_version
           hash['ohai_version'] = self.ohai_version
         end

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -13,9 +13,39 @@ class Stove::Cookbook
 
       context 'when the extra metadata is included' do
         it 'includes the new metadata fields' do
+          subject.source_url('http://foo.example.com')
+          subject.issues_url('http://bar.example.com')
           hash = subject.to_hash(true)
           expect(hash).to include('issues_url')
+          expect(hash['source_url']).to eq 'http://foo.example.com'
           expect(hash).to include('source_url')
+          expect(hash['issues_url']).to eq 'http://bar.example.com'
+        end
+      end
+
+      context 'when the extra metadata is not defined' do
+        it 'does not include the new metadata fields' do
+          hash = subject.to_hash(true)
+          expect(hash).not_to include('source_url')
+          expect(hash).not_to include('issues_url')
+        end
+      end
+
+      context 'when only some of the extra metadata is defined' do
+        it 'only includes the source_url if issues_url is empty' do
+          subject.source_url('http://foo.example.com')
+          hash = subject.to_hash(true)
+          expect(hash).to include('source_url')
+          expect(hash['source_url']).to eq 'http://foo.example.com'
+          expect(hash).not_to include('issues_url')
+        end
+
+        it 'only includes the issues_url if source_url is empty' do
+          subject.issues_url('http://bar.example.com')
+          hash = subject.to_hash(true)
+          expect(hash).to include('issues_url')
+          expect(hash['issues_url']).to eq 'http://bar.example.com'
+          expect(hash).not_to include('source_url')
         end
       end
     end


### PR DESCRIPTION
Only populate the extended metadata when it's present in `metadata.rb`

Based on @jf647's work in #82

Closes #81
Closes #82