### PR TITLE
Drop support for Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.0.0
-  - 2.1
-  - 2.2
-  - 2.3.0
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
 
 branches:
   only:

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 source 'https://rubygems.org'
 gemspec
+
+# this maintains compatiblity with Ruby 2.1
+gem 'rack', '< 2'

--- a/stove.gemspec
+++ b/stove.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.0'
+  spec.required_ruby_version = '>= 2.1'
 
   # Runtime dependencies
   spec.add_dependency 'chef-api', '~> 0.5'


### PR DESCRIPTION
Ruby 2.0 is EOL and ChefDK has shipped with 2.1+ since the beginning

Signed-off-by: Tim Smith <tsmith@chef.io>