### PR TITLE
time to switch the default to --extended-metadata

### DIFF
--- a/lib/stove/cli.rb
+++ b/lib/stove/cli.rb
@@ -118,8 +118,8 @@ module Stove
           options[:key] = v
         end
 
-        opts.on('--extended-metadata', 'Include non-backwards compatible metadata keys such as `issues_url`') do
-          options[:extended_metadata] = true
+        opts.on('--[no-]extended-metadata', 'Include non-backwards compatible metadata keys such as `issues_url`') do |v|
+          options[:extended_metadata] = v
         end
 
         opts.on('--no-ssl-verify', 'Turn off ssl verify') do
@@ -174,7 +174,7 @@ module Stove
         :endpoint          => nil,
         :username          => Config.username,
         :key               => Config.key,
-        :extended_metadata => false,
+        :extended_metadata => true,
         :ssl_verify        => true,
 
         # Git options


### PR DESCRIPTION
people on Chef < 12.5.1 will need to use `stove --no-extended-metadata`, but this will help reduce the number of user complaints about cookbooks on supermarket lacking issues or source urls due to cookbook authors not realizing that stove doesn't upload those by default (which certainly trolled me for a long time before i asked someone why i wasn't getting the urls).

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>