### PR TITLE
Drop support for Ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
 
 branches:
   only:
@@ -18,3 +18,7 @@ before_script:
   - git config --global user.name "Travis CI"
 
 script: bundle exec rake
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: 2.4.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-
-# this maintains compatiblity with Ruby 2.1
-gem 'rack', '< 2'

--- a/stove.gemspec
+++ b/stove.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.2'
 
   # Runtime dependencies
   spec.add_dependency 'chef-api', '~> 0.5'


### PR DESCRIPTION
These would fail anyways due to Rack's requirement on 2.2+

Signed-off-by: Tim Smith <tsmith@chef.io>