### PR TITLE
Use porcelain instead of short for git status validation, fixes #110

### DIFF
--- a/lib/stove/plugins/git.rb
+++ b/lib/stove/plugins/git.rb
@@ -8,7 +8,7 @@ module Stove
     end
 
     validate(:clean) do
-      git_null('status -s').strip.empty?
+      git_null('status --porcelain').strip.empty?
     end
 
     validate(:up_to_date) do


### PR DESCRIPTION
Updates call to git status to use `--porcelain` instead of `-s`, where the latter may be affected by user configuration.