### PR TITLE
Allow to have gem version in cookbook metadata.json

### DIFF
--- a/lib/stove/cookbook/metadata.rb
+++ b/lib/stove/cookbook/metadata.rb
@@ -57,8 +57,12 @@ module Stove
 
         def def_meta_gems(field, instance_variable)
           class_eval <<-EOM, __FILE__, __LINE__ + 1
-            def #{field}(thing)
-              @#{instance_variable} << thing
+            def #{field}(gem_name, *args)
+              version = args.first
+              gem_params = []
+              gem_params << gem_name
+              gem_params << version if version
+              @#{instance_variable} << gem_params
             end
           EOM
         end

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -23,7 +23,7 @@ class Stove::Cookbook
           expect(hash).to include('source_url')
           expect(hash['issues_url']).to eq 'http://bar.example.com'
           expect(hash).to include('gems')
-          expect(hash['gems']).to eq(['rspec'])
+          expect(hash['gems']).to eq([['rspec']])
         end
       end
 
@@ -57,7 +57,7 @@ class Stove::Cookbook
           subject.gem('rspec')
           hash = subject.to_hash(true)
           expect(hash).to include('gems')
-          expect(hash['gems']).to eq(['rspec'])
+          expect(hash['gems']).to eq([['rspec']])
           expect(hash).not_to include('source_url')
           expect(hash).not_to include('issues_url')
         end


### PR DESCRIPTION
Hello,

please, consider my PR.

Currently stove throws an error if version of gem is specified in metadata.rb

```
E: /opt/chefdk/embedded/lib/ruby/gems/2.1.0/bundler/gems/stove-53b40c828229/lib/stove/cookbook/metadata.rb:60:in `gem'
/opt/chefdk/chef-repo/cookbooks/sys_dns/metadata.rb:17:in `from_file'
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/bundler/gems/stove-53b40c828229/lib/stove/cookbook/metadata.rb:160:in `instance_eval'
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/bundler/gems/stove-53b40c828229/lib/stove/cookbook/metadata.rb:160:in `from_file'
/opt/chefdk/embedded/lib/ruby/gems/2.1.0/bundler/gems/stove-53b40c828229/lib/stove/cookbook/metadata.rb:28:in `from_file'
```

This change allows to specify gem version in cookbook's metadata.rb and also to write it to metadata.json when publishing a new cookbook.

Thanks.