### PR TITLE
Match Chef’s metadata behavior with chef_version and ohai_version.

### DIFF
--- a/lib/stove/cookbook/metadata.rb
+++ b/lib/stove/cookbook/metadata.rb
@@ -62,6 +62,15 @@ module Stove
             end
           EOM
         end
+
+        def def_meta_version(field)
+          class_eval <<-EOM, __FILE__, __LINE__ + 1
+            def #{field}(*thing)
+              @#{field} << thing unless thing.empty?
+              @#{field}
+            end
+          EOM
+        end
       end
 
       DEFAULT_VERSION = '>= 0.0.0'.freeze
@@ -85,8 +94,8 @@ module Stove
       # these attributes are here.
       def_attribute :source_url
       def_attribute :issues_url
-      def_attribute :chef_version
-      def_attribute :ohai_version
+      def_meta_version :chef_version
+      def_meta_version :ohai_version
       def_attribute :gem
 
       def_meta_cookbook :supports,   :platforms
@@ -123,8 +132,8 @@ module Stove
         @source_url       = Stove::Mash.new
         @issues_url       = Stove::Mash.new
         @gems             = []
-        @chef_version     = Stove::Mash.new
-        @ohai_version     = Stove::Mash.new
+        @chef_version     = []
+        @ohai_version     = []
         @platforms        = Stove::Mash.new
         @dependencies     = Stove::Mash.new
         @recommendations  = Stove::Mash.new
@@ -205,8 +214,8 @@ module Stove
           hash['source_url']   = self.source_url unless self.source_url.empty?
           hash['issues_url']   = self.issues_url unless self.issues_url.empty?
           hash['gems']         = self.gems unless self.gems.empty?
-          hash['chef_version'] = self.chef_version
-          hash['ohai_version'] = self.ohai_version
+          hash['chef_version'] = self.chef_version.map(&:sort)
+          hash['ohai_version'] = self.ohai_version.map(&:sort)
         end
 
         return hash

--- a/spec/unit/cookbook/metadata_spec.rb
+++ b/spec/unit/cookbook/metadata_spec.rb
@@ -63,5 +63,78 @@ class Stove::Cookbook
         end
       end
     end
+
+    describe '#chef_version' do
+      let(:hash_version) { subject.to_hash(true)['chef_version'] }
+
+      context 'with no chef_version line' do
+        it 'returns []' do
+          expect(subject.chef_version).to eq []
+          expect(hash_version).to eq []
+        end
+      end
+
+      context 'with a single chef_version requirement' do
+        it 'returns [[req]]' do
+          subject.chef_version('>= 12.0')
+          expect(subject.chef_version).to eq [['>= 12.0']]
+          expect(hash_version).to eq [['>= 12.0']]
+        end
+      end
+
+      context 'with a multi-part chef_version requirement' do
+        it 'returns [[req1, req2]]' do
+          subject.chef_version('>= 12.0', '< 14.0')
+          expect(subject.chef_version).to eq [['>= 12.0', '< 14.0']]
+          expect(hash_version).to eq [['< 14.0', '>= 12.0',]]
+        end
+      end
+
+      context 'with multiple chef_version requirements' do
+        it 'returns [[req1], [req2]]' do
+          subject.chef_version('< 12')
+          subject.chef_version('> 14')
+          expect(subject.chef_version).to eq [['< 12'], ['> 14']]
+          expect(hash_version).to eq [['< 12'], ['> 14']]
+        end
+      end
+    end
+
+    describe '#ohai_version' do
+      let(:hash_version) { subject.to_hash(true)['ohai_version'] }
+
+      context 'with no ohai_version line' do
+        it 'returns []' do
+          expect(subject.ohai_version).to eq []
+          expect(hash_version).to eq []
+        end
+      end
+
+      context 'with a single ohai_version requirement' do
+        it 'returns [[req]]' do
+          subject.ohai_version('>= 12.0')
+          expect(subject.ohai_version).to eq [['>= 12.0']]
+          expect(hash_version).to eq [['>= 12.0']]
+        end
+      end
+
+      context 'with a multi-part ohai_version requirement' do
+        it 'returns [[req1, req2]]' do
+          subject.ohai_version('>= 12.0', '< 14.0')
+          expect(subject.ohai_version).to eq [['>= 12.0', '< 14.0']]
+          expect(hash_version).to eq [['< 14.0', '>= 12.0',]]
+        end
+      end
+
+      context 'with multiple ohai_version requirements' do
+        it 'returns [[req1], [req2]]' do
+          subject.ohai_version('< 12')
+          subject.ohai_version('> 14')
+          expect(subject.ohai_version).to eq [['< 12'], ['> 14']]
+          expect(hash_version).to eq [['< 12'], ['> 14']]
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This will be important as more cookbooks start doing stuff like `chef_version `>= 12.5', '< 14'` instead of the semver pin. Should match the current state of Chef's metadata handling.