### PR TITLE
Load stove out of the current directory for dev

### DIFF
--- a/bin/stove
+++ b/bin/stove
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
 
+$:.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 require 'stove'
 Stove::Cli.new(ARGV.dup).execute!


### PR DESCRIPTION
It looks me a bit to realize I was running from the git repo, but actually loading the gem. This makes sure we're loading from the current path.

Signed-off-by: Tim Smith <tsmith@chef.io>