### PR TITLE
Add support for Artifactory's user-password auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ bin/rake publish
 
 In addition to uploading to a standard [Supermarket](https://github.com/chef/supermarket) server, Stove can upload to an Artifactory repository [configured to be in Chef mode](https://www.jfrog.com/confluence/display/RTF/Chef+Cookbook+Repositories).
 
-You specify the URL to upload to via `--artifactory`, which you can find the URL Artifactory repository configuration. Your API key can be specified either in the `$ARTIFACTORY_API_KEY` environment variable or via `--artifactory-key`:
+You specify the URL to upload to via `--artifactory`, which you can find the URL Artifactory repository configuration. If you use API keys, the API key can be specified either in the `$ARTIFACTORY_API_KEY` environment variable or via `--artifactory-key`. If you are using HTTPS authentication, include the username and password into your Artifactory URL.
 
 ```bash
 # API key in $ARTIFACTORY_API_KEY
@@ -89,6 +89,8 @@ $ stove --artifactory https://artifactory.example.com/api/chef/nameofrepo
 $ stove --artifactory https://artifactory.example.com/api/chef/nameofrepo --artifactory-key=@path/to/key/file
 # API key on the command line
 $ stove --artifactory https://artifactory.example.com/api/chef/nameofrepo --artifactory-key=XZg6tefUZYfiglmSbQ1s1e6habk
+# User and password for HTTPS authentication
+$ stove --artifactory https://user:password@artifactory.example.com/api/chef/nameofrepo
 ```
 
 ## Contributing

--- a/lib/stove/error.rb
+++ b/lib/stove/error.rb
@@ -51,6 +51,6 @@ module Stove
     class GitCleanValidationFailed < ValidationFailed; end
     class GitRepositoryValidationFailed < ValidationFailed; end
     class GitUpToDateValidationFailed < ValidationFailed; end
-    class ArtifactoryKeyValidationFailed < ValidationFailed; end
+    class ArtifactoryCredentialsValidationFailed < ValidationFailed; end
   end
 end

--- a/lib/stove/plugins/artifactory.rb
+++ b/lib/stove/plugins/artifactory.rb
@@ -1,10 +1,17 @@
+require 'net/https'
+
 module Stove
   class Plugin::Artifactory < Plugin::Base
     id 'artifactory'
     description 'Publish the release to an Artifactory server'
 
-    validate(:key) do
-      Config.artifactory_key && !Config.artifactory_key.strip.empty?
+    validate(:credentials) do
+      if Config.artifactory_key
+        !Config.artifactory_key.strip.empty?
+      else
+        url = URI.parse(Config.artifactory.strip)
+        url.user and url.password and url.scheme == 'https'
+      end
     end
 
     run('Publishing the release to the Artifactory server') do

--- a/spec/unit/artifactory_spec.rb
+++ b/spec/unit/artifactory_spec.rb
@@ -68,6 +68,19 @@ describe Stove::Artifactory do
       end
     end
 
+    context 'with HTTPS authentication' do
+      before do
+        Stove::Config.artifactory_key = ''
+        Stove::Config.artifactory = 'https://username:passw%40rd@artifactory.example/api/chef/chef'
+      end
+
+      it 'uploads the file' do
+        stub_request(:get, 'https://artifactory.example/api/chef/chef/api/v1/cookbooks/testcook/versions/1.2.3').with(headers: {'authorization' => 'Basic dXNlcm5hbWU6cGFzc3dAcmQ='}).to_return(body: '')
+        stub_request(:post, 'https://artifactory.example/api/chef/chef/api/v1/cookbooks/testcook.tgz').with(headers: {'authorization' => 'Basic dXNlcm5hbWU6cGFzc3dAcmQ='}, body: 'simple').to_return(status: 201)
+        expect { subject }.to_not raise_error
+      end
+    end
+
   end
 
   # Break encapsulation a bit to test the ssl_verify configuration.

--- a/templates/errors/artifactory_credentials_validation_failed.erb
+++ b/templates/errors/artifactory_credentials_validation_failed.erb
@@ -9,3 +9,7 @@ Or via a file path:
 Or via an environment variable:
 
     export ARTIFACTORY_API_KEY=sUeEpLXJvfhw3UZHbVPrGCgdou8VI6fXpD5sUHd0pKAxCmuGWNHLgerpFPkCJ2EjBBPYcM4My
+
+Or via the URL (--artifactory [URL]), if you are using HTTPS authentication:
+
+    stove --artifactory https://username:password@artifactory.example.com/api/chef/nameofrepo


### PR DESCRIPTION
On Artifactory accounts with extra security enabled, users don't appear to be
able to generate their own API keys - they are required to use their
username and an encrypted password. This change makes Stove work with
this authentication scheme.