### PR TITLE
Add missing stringio require to fix ruby 3.1

### DIFF
--- a/.expeditor/run_linux_tests.sh
+++ b/.expeditor/run_linux_tests.sh
@@ -2,46 +2,18 @@
 #
 # This script runs a passed in command, but first setups up the bundler caching on the repo
 
-set -e
+set -ue
 
 export USER="root"
+export LANG=C.UTF-8 LANGUAGE=C.UTF-8
 
-# make sure we have the aws cli
-apt-get update -y
-apt-get install awscli -y
-
-# grab the s3 bundler if it's there and use it for all operations in bundler
-echo "Fetching bundle cache archive from s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz"
-aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz" bundle.tar.gz || echo 'Could not pull the bundler archive from s3 for caching. Builds may be slower than usual as all gems will have to install.'
-aws s3 cp "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" bundle.sha256 || echo "Could not pull the sha256 hash of the vendor/bundle directory from s3. Without this we will compress and upload the bundler archive to S3 even if it hasn't changed"
-
-echo "Restoring the bundle cache archive to vendor/bundle"
-if [ -f bundle.tar.gz ]; then
-  tar -xzf bundle.tar.gz
-fi
-
+# necessary for stove tests
 git config --global user.email "foo@example.com"
 git config --global user.name "Foo Bar"
 
+echo "--- bundle install"
 bundle config --local path vendor/bundle
 bundle install --jobs=7 --retry=3
-bundle exec $1
 
-if [[ -f bundle.tar.gz && -f bundle.sha256  ]]; then # dont' check the sha if we're missing either file
-  if shasum --check bundle.sha256 --status; then # if the the sha matches we're done
-    echo "Bundled gems have not changed. Skipping upload to s3"
-    exit
-  fi
-fi
-
-echo "Generating sha256 hash file of the vendor/bundle directory to ship to s3"
-shasum -a 256 vendor/bundle > bundle.sha256
-
-echo "Creating the tar.gz to of the vendor/bundle directory to ship to s3"
-tar -czf bundle.tar.gz vendor/
-
-echo "Uploading the tar.gz of the vendor/bundle directory to s3"
-aws s3 cp bundle.tar.gz "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.tar.gz" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'
-
-echo "Uploading the sha256 hash of the vendor/bundle directory to s3"
-aws s3 cp bundle.sha256 "s3://public-cd-buildkite-cache/${BUILDKITE_PIPELINE_SLUG}/${BUILDKITE_LABEL}/bundle.sha256" || echo 'Could not push the bundler directory to s3 for caching. Future builds may be slower if this continues.'
+echo "+++ bundle exec task"
+bundle exec $@

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,3 +1,13 @@
+expeditor:
+  cached_folders:
+    - vendor
+  defaults:
+    buildkite:
+      retry:
+        automatic:
+          limit: 1
+      timeout_in_minutes: 30
+
 steps:
 
 - label: run-specs-ruby-2.5

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,28 +1,12 @@
 steps:
 
-- label: run-specs-ruby-2.3
-  command:
-    - .expeditor/run_linux_tests.sh "rake"
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.3
-
-- label: run-specs-ruby-2.4
-  command:
-    - .expeditor/run_linux_tests.sh "rake"
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-buster
-
 - label: run-specs-ruby-2.5
   command:
     - .expeditor/run_linux_tests.sh "rake"
   expeditor:
     executor:
       docker:
-        image: ruby:2.5-buster
+        image: ruby:2.5
 
 - label: run-specs-ruby-2.6
   command:
@@ -30,4 +14,28 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-buster
+        image: ruby:2.6
+
+- label: run-specs-ruby-2.7
+  command:
+    - .expeditor/run_linux_tests.sh "rake"
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.7
+
+- label: run-specs-ruby-3.0
+  command:
+    - .expeditor/run_linux_tests.sh "rake"
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.0
+
+- label: run-specs-ruby-3.1
+  command:
+    - .expeditor/run_linux_tests.sh "rake"
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.1

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec name: 'stove'
 # testing compatibility
 gem 'rack', '< 2'
 gem 'webrick'
+gem 'cucumber', '< 8' # ruby 2.5 compat

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gemspec name: 'stove'
 
 # testing compatibility
 gem 'rack', '< 2'
+gem 'webrick'

--- a/lib/stove/packager.rb
+++ b/lib/stove/packager.rb
@@ -2,6 +2,7 @@ require 'rubygems/package'
 require 'fileutils'
 require 'tempfile'
 require 'zlib'
+require 'stringio'
 
 module Stove
   class Packager

--- a/stove.gemspec
+++ b/stove.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = 'stove'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.5'
 
   # Runtime dependencies
   spec.add_dependency 'chef-api', '~> 0.5'


### PR DESCRIPTION
Stove fails on Ruby 3.1. Rubygems or Bundler probably required stringio
before and it worked. Now it does not.

Signed-off-by: Tim Smith <tsmith84@gmail.com>